### PR TITLE
now installs 2.7.10 as fallback and refactor HTTP requests

### DIFF
--- a/install_python27.sh
+++ b/install_python27.sh
@@ -130,7 +130,7 @@ python_install() {
     if grep -qio "${dest}/python$python2vers/lib" /etc/ld.so.conf.d/local-lib.conf; then
       true
     else
-      echo "${dest}/python$python2vers/lib" >> /etc/ld.so.conf.d/local-lib.conf
+      sed -i "1i ${dest}/python$python2vers/lib" /etc/ld.so.conf.d/local-lib.conf
     fi
   else
     echo "${dest}/python$python2vers/lib" >> /etc/ld.so.conf.d/local-lib.conf

--- a/install_python27.sh
+++ b/install_python27.sh
@@ -43,21 +43,31 @@ sqlitesrc="http://www.sqlite.org/2013/$sqliteautoconf.tar.gz"
 clear ;
 
 json_val() {
-  KEY=$1
-  awk -F"[\"]" '{for(i=1;i<=NF;i++){ if($i~/'$KEY'/){ print $(i+2) }}}'
+  key=$1
+  awk -F"[\"]" '{for(i=1;i<=NF;i++){ if($i~/'$key'/){ print $(i+2) }}}'
 }
 
 python_info() {
-  if [ "$usescriptio" == "true" ]; then
-    OUT=$( curl -L -m 5 -qSfsw '\n%{http_code}' script.io/disks/python/python2 2>/dev/null )
-    RET=$?
-    STAT=$( echo "$OUT" | tail -n1 )
-    RESP=$( echo "$OUT" | head -n-1 )
+  if [[ "$usescriptio" == "true" ]]; then
+    for i in {1..3}
+    do
+      out=$( curl -L -m 5 -qSfsw '\n%{http_code}' script.io/disks/python/python2 2>/dev/null )
+      ret=$?
+      stat=$( echo "$out" | tail -n1 )
+      resp=$( echo "$out" | head -n-1 )
 
-    if [[ ($RET -eq 0) && ("$STAT" == "200") ]]; then
-      python2vers=$( echo $RESP | json_val version )
-      python2url=$( echo $RESP | json_val url )
-    fi
+      if [[ ($ret -eq 0) && ("$stat" == "200") ]]; then
+        python2vers=$( echo $resp | json_val version )
+        python2url=$( echo $resp | json_val url )
+        break
+      fi
+
+      if [[ ($ret -ne 0) || ("$stat" != "429") ]]; then
+        break
+      fi
+
+      sleep 1
+    done
   fi
 
   if [[ -z "$python2vers" || -z "$python2url" ]]; then


### PR DESCRIPTION
pip is included by Python 2.7.9 and later by default.

Getting version and url from one single HTTP request can guarantee the integrality of version & url.

If you installed Python with this script before, you probably can not use the new version installed this time. Inserting the lib path of the new version before the older one in `/etc/ld.so.conf.d/local-lib.conf` can fix this problem.
